### PR TITLE
Support react 18 in react sdk

### DIFF
--- a/.changeset/big-moons-repair.md
+++ b/.changeset/big-moons-repair.md
@@ -1,0 +1,5 @@
+---
+'@gnosis.pm/safe-apps-react-sdk': minor
+---
+
+Support react 18

--- a/packages/safe-apps-react-sdk/package.json
+++ b/packages/safe-apps-react-sdk/package.json
@@ -14,7 +14,7 @@
     "@gnosis.pm/safe-apps-sdk": "7.4.0"
   },
   "peerDependencies": {
-    "react": "16.x.x || 17.x.x"
+    "react": "16.x.x || 17.x.x || 18.x.x"
   },
   "devDependencies": {
     "@types/react": "^17.0.47",

--- a/packages/safe-apps-react-sdk/src/index.tsx
+++ b/packages/safe-apps-react-sdk/src/index.tsx
@@ -12,6 +12,7 @@ const SafeContext = createContext<SafeReactSDKContext | undefined>(undefined);
 interface Props {
   loader?: ReactElement;
   opts?: SDKOpts;
+  children: React.ReactNode;
 }
 
 export const SafeProvider: React.FC<Props> = ({ loader = null, opts, children }) => {


### PR DESCRIPTION
This PR:
- Adds support for react 18 in the react SDK. The only change needed was to add an explicit declaration for the `children` prop for the provider component. See change explanation here https://reactjs.org/blog/2022/03/08/react-18-upgrade-guide.html#updates-to-typescript-definitions