### PR TITLE
Chore: include source files in npm package

### DIFF
--- a/.changeset/stupid-moose-destroy.md
+++ b/.changeset/stupid-moose-destroy.md
@@ -1,0 +1,9 @@
+---
+'@gnosis.pm/safe-apps-react-sdk': patch
+'@gnosis.pm/safe-apps-sdk': patch
+'@gnosis.pm/safe-apps-wagmi': patch
+'@gnosis.pm/safe-apps-web3-react': patch
+'@gnosis.pm/safe-apps-web3modal': patch
+---
+
+Include source files in the npm package to make sourcemaps work

--- a/packages/safe-apps-provider/package.json
+++ b/packages/safe-apps-provider/package.json
@@ -4,6 +4,12 @@
   "description": "A provider wrapper of Safe Apps SDK",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
+  "files": [
+    "dist/**/*",
+    "src/**/*",
+    "CHANGELOG.md",
+    "README.md"
+  ],
   "scripts": {
     "build": "yarn rimraf dist && tsc",
     "test": "echo No tests specified"

--- a/packages/safe-apps-react-sdk/package.json
+++ b/packages/safe-apps-react-sdk/package.json
@@ -3,12 +3,14 @@
   "private": false,
   "version": "4.4.0",
   "main": "dist/index.js",
-  "types": "dist/index.d.ts",
-  "license": "MIT",
+  "typings": "dist/index.d.ts",
   "files": [
     "dist/**/*",
+    "src/**/*",
+    "CHANGELOG.md",
     "README.md"
   ],
+  "license": "MIT",
   "author": "Gnosis (https://gnosis.io)",
   "dependencies": {
     "@gnosis.pm/safe-apps-sdk": "7.4.0"

--- a/packages/safe-apps-sdk/dist/package.json
+++ b/packages/safe-apps-sdk/dist/package.json
@@ -6,6 +6,8 @@
     "typings": "dist/src/index.d.ts",
     "_files": [
         "dist/**/*",
+        "src/**/*",
+        "CHANGELOG.md",
         "README.md"
     ],
     "keywords": [

--- a/packages/safe-apps-sdk/package.json
+++ b/packages/safe-apps-sdk/package.json
@@ -6,6 +6,8 @@
   "typings": "dist/src/index.d.ts",
   "files": [
     "dist/**/*",
+    "src/**/*",
+    "CHANGELOG.md",
     "README.md"
   ],
   "keywords": [

--- a/packages/safe-apps-wagmi/package.json
+++ b/packages/safe-apps-wagmi/package.json
@@ -6,6 +6,8 @@
   "typings": "dist/index.d.ts",
   "files": [
     "dist/**/*",
+    "src/**/*",
+    "CHANGELOG.md",
     "README.md"
   ],
   "keywords": [

--- a/packages/safe-apps-web3-react/package.json
+++ b/packages/safe-apps-web3-react/package.json
@@ -6,6 +6,8 @@
   "typings": "dist/index.d.ts",
   "files": [
     "dist/**/*",
+    "src/**/*",
+    "CHANGELOG.md",
     "README.md"
   ],
   "keywords": [

--- a/packages/safe-apps-web3modal/package.json
+++ b/packages/safe-apps-web3modal/package.json
@@ -6,6 +6,8 @@
   "typings": "dist/index.d.ts",
   "files": [
     "dist/**/*",
+    "src/**/*",
+    "CHANGELOG.md",
     "README.md"
   ],
   "scripts": {


### PR DESCRIPTION
After upgrading the template to react-scripts 5, it has many errors because our packages include a source map in the build but not the source files this source maps reference.

Warning example:
```
WARNING in ./node_modules/@gnosis.pm/safe-apps-sdk/dist/src/txs/index.js
Module Warning (from ./node_modules/source-map-loader/dist/cjs.js):
Failed to parse source map from '/Users/mmv/projects/gnosis/drain-safe/node_modules/@gnosis.pm/safe-apps-sdk/src/txs/index.ts' file: Error: ENOENT: no such file or directory, open '/Users/mmv/projects/gnosis/drain-safe/node_modules/@gnosis.pm/safe-apps-sdk/src/txs/index.ts'
```

After doing some research, it looks like it's a good practice to publish source files for typescript files and source maps for proper debugging support: https://stackoverflow.com/questions/57530478/is-it-recommended-to-publish-source-files-for-typescript-node-modules.