### PR TITLE
Populate `safeTxGas` using the provided gas limit (`SafeAppProvider`)	

### DIFF
--- a/.changeset/mean-kiwis-add.md
+++ b/.changeset/mean-kiwis-add.md
@@ -1,0 +1,5 @@
+---
+'@gnosis.pm/safe-apps-provider': minor
+---
+
+Pass the gas limit to `safeTxGas` when sending a transaction through the Safe app provider

--- a/packages/safe-apps-provider/src/provider.ts
+++ b/packages/safe-apps-provider/src/provider.ts
@@ -87,6 +87,7 @@ export class SafeAppProvider extends EventEmitter implements EIP1193Provider {
 
         const resp = await this.sdk.txs.send({
           txs: [tx],
+          params: { safeTxGas: tx.gas },
         });
         // Store fake transaction
         this.submittedTxs.set(resp.safeTxHash, {


### PR DESCRIPTION
Currently, it is not possible to populate the `safeTxGas` when using a safe app that communicates through the `SafeAppProvider` (e.g. WalletConnect).

This PR updates the Safe App Provider to forward the provided gas limit to `safeTxGas`. This is helpful in many cases where a gas buffer is required to avoid "Out of gas" errors.