### PR TITLE
Downgrade `@testing-library/react` to the version supporting react 17

### DIFF
--- a/.changeset/friendly-students-tickle.md
+++ b/.changeset/friendly-students-tickle.md
@@ -1,0 +1,5 @@
+---
+'@gnosis.pm/cra-template-safe-app': patch
+---
+
+Downgrade @testing-library/react to the version that supports react 17

--- a/packages/cra-template-safe-app/template.json
+++ b/packages/cra-template-safe-app/template.json
@@ -12,7 +12,7 @@
     },
     "devDependencies": {
       "@testing-library/jest-dom": "^5.16.5",
-      "@testing-library/react": "^13.4.0",
+      "@testing-library/react": "^12.1.5",
       "@testing-library/user-event": "^14.4.3",
       "@types/jest": "^29.2.0",
       "@types/node": "^18.11.7",


### PR DESCRIPTION
This PR:
Fixes #400 by downgrading the `@testing-library/react` library by one major version, so it is compatible with the version of `react` library we're using.

To test:
```
npx create-react-app my-safe-app --template file:../path-to-template
```