### PR TITLE
[PoC] feat: immediately return string signatures

### DIFF
--- a/packages/safe-apps-sdk/src/txs/index.ts
+++ b/packages/safe-apps-sdk/src/txs/index.ts
@@ -8,6 +8,7 @@ import {
   SendTransactionsResponse,
   SignTypedMessageParams,
   EIP712TypedData,
+  EIP1271Signature,
   isObjectEIP712TypedData,
 } from '../types';
 
@@ -32,20 +33,21 @@ class TXs {
     return response.data;
   }
 
-  async signMessage(message: string): Promise<SendTransactionsResponse> {
+  async signMessage(message: string): Promise<SendTransactionsResponse | EIP1271Signature> {
     const messagePayload = {
       message,
     };
 
-    const response = await this.communicator.send<Methods.signMessage, SignMessageParams, SendTransactionsResponse>(
+    const response = await this.communicator.send<
       Methods.signMessage,
-      messagePayload,
-    );
+      SignMessageParams,
+      SendTransactionsResponse | EIP1271Signature
+    >(Methods.signMessage, messagePayload);
 
     return response.data;
   }
 
-  async signTypedMessage(typedData: EIP712TypedData): Promise<SendTransactionsResponse> {
+  async signTypedMessage(typedData: EIP712TypedData): Promise<SendTransactionsResponse | EIP1271Signature> {
     if (!isObjectEIP712TypedData(typedData)) {
       throw new Error('Invalid typed data');
     }
@@ -53,7 +55,7 @@ class TXs {
     const response = await this.communicator.send<
       Methods.signTypedMessage,
       SignTypedMessageParams,
-      SendTransactionsResponse
+      SendTransactionsResponse | EIP1271Signature
     >(Methods.signTypedMessage, { typedData });
 
     return response.data;

--- a/packages/safe-apps-sdk/src/types/messaging.ts
+++ b/packages/safe-apps-sdk/src/types/messaging.ts
@@ -3,6 +3,8 @@ import { SafeInfo, ChainInfo, SendTransactionsResponse, EnvironmentInfo, Address
 import { GatewayTransactionDetails, SafeBalances } from './gateway';
 import { Permission } from './permissions';
 
+export type EIP1271Signature = string;
+
 export type RequestId = string;
 
 export type InterfaceMessageEvent = MessageEvent<Response>;
@@ -14,8 +16,8 @@ export interface MethodToResponse {
   [Methods.getChainInfo]: ChainInfo;
   [Methods.getTxBySafeTxHash]: GatewayTransactionDetails;
   [Methods.getSafeBalances]: SafeBalances[];
-  [Methods.signMessage]: SendTransactionsResponse;
-  [Methods.signTypedMessage]: SendTransactionsResponse;
+  [Methods.signMessage]: SendTransactionsResponse | EIP1271Signature;
+  [Methods.signTypedMessage]: SendTransactionsResponse | EIP1271Signature;
   [Methods.getEnvironmentInfo]: EnvironmentInfo;
   [Methods.requestAddressBook]: AddressBookItem[];
   [Methods.wallet_getPermissions]: Permission[];

--- a/packages/safe-apps-sdk/src/types/sdk.ts
+++ b/packages/safe-apps-sdk/src/types/sdk.ts
@@ -1,5 +1,6 @@
 import { ChainInfo as _ChainInfo } from '@gnosis.pm/safe-react-gateway-sdk';
 import { BigNumberish, BytesLike } from 'ethers';
+import { EIP1271Signature } from './messaging';
 
 export type ChainInfo = Pick<
   _ChainInfo,
@@ -86,4 +87,8 @@ export type AddressBookItem = {
 
 export const isObjectEIP712TypedData = (obj?: unknown): obj is EIP712TypedData => {
   return typeof obj === 'object' && obj != null && 'domain' in obj && 'types' in obj && 'message' in obj;
+};
+
+export const isEIP1271Signature = (res: SendTransactionsResponse | EIP1271Signature): res is EIP1271Signature => {
+  return typeof res === 'string';
 };

--- a/packages/safe-apps-test-app/src/tabs/Main.tsx
+++ b/packages/safe-apps-test-app/src/tabs/Main.tsx
@@ -59,9 +59,8 @@ const Main = ({ sdk, safeInfo }: OwnProps): React.ReactElement => {
 
   const handleSignMessageClick = async () => {
     const signResult = await sdk.txs.signMessage(message);
-
     setSignature(isEIP1271Signature(signResult) ? signResult : undefined);
-    console.log({ signature });
+    console.log('Signature: ', isEIP1271Signature(signResult) ? signResult : undefined);
   };
 
   const handleCheckSignatureClick = async () => {
@@ -82,9 +81,9 @@ const Main = ({ sdk, safeInfo }: OwnProps): React.ReactElement => {
     }
     console.log({ message });
 
-    const signResult = sdk.txs.signTypedMessage(message);
+    const signResult = await sdk.txs.signTypedMessage(message);
     setSignature(isEIP1271Signature(signResult) ? signResult : undefined);
-    console.log({ signature });
+    console.log('Signature: ', isEIP1271Signature(signResult) ? signResult : undefined);
   };
 
   const handleCheckTypedSignatureClick = async () => {


### PR DESCRIPTION
## What this PR solves

Proof of concept for immediately returning signatures for [#1206](https://github.com/safe-global/web-core/issues/1206)

## How this PR fixes it

If `web-core` returns a string (theoretically on 1/n Safes), the signature will be saved/can be validated in the `safe-apps-test-app`.

This PR predominantly adjusts types and will be used as a test reference.