### PR TITLE
fix: `TypeError: can't convert BigInt to number`

### DIFF
--- a/packages/cra-template-safe-app/template.json
+++ b/packages/cra-template-safe-app/template.json
@@ -39,8 +39,18 @@
       "eject": "react-scripts eject"
     },
     "browserslist": {
-      "production": [">0.2%", "not dead", "not op_mini all"],
-      "development": ["last 1 chrome version", "last 1 firefox version", "last 1 safari version"]
+      "production": [
+        "chrome >= 67",
+        "edge >= 79",
+        "firefox >= 68",
+        "opera >= 54",
+        "safari >= 14"
+      ],
+      "development": [
+        "last 1 chrome version",
+        "last 1 firefox version",
+        "last 1 safari version"
+      ]
     }
   }
 }


### PR DESCRIPTION
After the following
```sh
$ npx create-react-app my-safe-app --template @safe-global/cra-template-safe-app
$ cd my-safe-app
$ npm i
$ npm run build
```
The build would display a blank page with `TypeError: can't convert BigInt to number` error in console.

I applied [this solution](https://github.com/paulmillr/noble-ed25519/issues/23#issuecomment-1109248320) and it fixed the issue.