### PR TITLE
Feature: add `sideEffects` property to package.json to improve tree-shaking

### DIFF
--- a/.changeset/forty-jokes-sing.md
+++ b/.changeset/forty-jokes-sing.md
@@ -1,0 +1,7 @@
+---
+'@safe-global/safe-apps-react-sdk': minor
+'@safe-global/safe-apps-provider': minor
+'@safe-global/safe-apps-sdk': minor
+---
+
+Add sideEffects false to package.json to improve tree-shaking

--- a/packages/safe-apps-provider/package.json
+++ b/packages/safe-apps-provider/package.json
@@ -10,6 +10,7 @@
     "CHANGELOG.md",
     "README.md"
   ],
+  "sideEffects": false,
   "scripts": {
     "build": "yarn rimraf dist && tsc",
     "test": "echo No tests specified"

--- a/packages/safe-apps-react-sdk/package.json
+++ b/packages/safe-apps-react-sdk/package.json
@@ -10,6 +10,7 @@
     "CHANGELOG.md",
     "README.md"
   ],
+  "sideEffects": false,
   "license": "MIT",
   "author": "Safe (https://safe.global)",
   "dependencies": {

--- a/packages/safe-apps-sdk/dist/package.json
+++ b/packages/safe-apps-sdk/dist/package.json
@@ -10,6 +10,7 @@
         "CHANGELOG.md",
         "README.md"
     ],
+    "sideEffects": false,
     "keywords": [
         "Safe",
         "sdk",
@@ -17,7 +18,7 @@
     ],
     "scripts": {
         "test": "jest",
-        "format-dist": "sed -i '' 's/\"files\":/\"_files\":/' dist/package.json",
+        "format-dist": "sed -i 's/\"files\":/\"_files\":/' dist/package.json",
         "build": "yarn rimraf dist && tsc && yarn format-dist"
     },
     "author": "Safe (https://safe.global)",

--- a/packages/safe-apps-sdk/package.json
+++ b/packages/safe-apps-sdk/package.json
@@ -10,6 +10,7 @@
     "CHANGELOG.md",
     "README.md"
   ],
+  "sideEffects": false,
   "keywords": [
     "Safe",
     "sdk",


### PR DESCRIPTION
This PR:
- Implements #500 

From the issue:
> Without "sideEffects" switched off (e.g. "sideEffects": false) build systems aren't able to properly eliminate dead code (e.g. Next.js) and could still load these packages even if they are not used.

More info: https://webpack.js.org/guides/tree-shaking/#mark-the-file-as-side-effect-free