### PR TITLE
Update lerna README instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,10 +34,7 @@ You can directly use [our production interface](https://app.safe.global) for tes
 ### Installing dependencies
 
 ```
-npm i -g lerna
-yarn global add lerna
-
-lerna bootstrap
+yarn install
 ```
 
 ### Running commands
@@ -47,13 +44,13 @@ We will use `build` command as an example. Same applies to other commands.
 For all packages:
 
 ```
-lerna run build
+yarn build
 ```
 
 For a specific package:
 
 ```
-lerna run --scope @safe-global/safe-apps-sdk build --stream
+yarn lerna run --scope @safe-global/safe-apps-sdk build --stream
 ```
 
 `--stream` options enables command output. By default, lerna displays it only in case of an error.

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   },
   "scripts": {
     "start:test-app": "yarn workspace @safe-global/safe-apps-test-app start",
+    "build": "lerna run build --stream",
     "build:sdk": "lerna run --scope @safe-global/safe-apps-sdk build --stream",
     "test:sdk": "lerna run --scope @safe-global/safe-apps-sdk test --stream",
     "release": "lerna run build && changeset publish",


### PR DESCRIPTION
Starting from `lerna` v7 they relay the dependency management completely to yarn or npm