### PR TITLE
Version Packages

### DIFF
--- a/.changeset/hungry-lizards-obey.md
+++ b/.changeset/hungry-lizards-obey.md
@@ -1,5 +1,0 @@
----
-'@safe-global/safe-apps-provider': patch
----
-
-fallback `value` and `data` were overwritten with `undefined`

--- a/packages/safe-apps-provider/CHANGELOG.md
+++ b/packages/safe-apps-provider/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @safe-global/safe-apps-provider
 
+## 0.18.1
+
+### Patch Changes
+
+- d6baa64: fallback `value` and `data` were overwritten with `undefined`
+
 ## 0.18.0
 
 ### Minor Changes

--- a/packages/safe-apps-provider/package.json
+++ b/packages/safe-apps-provider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@safe-global/safe-apps-provider",
-  "version": "0.18.0",
+  "version": "0.18.1",
   "description": "A provider wrapper of Safe Apps SDK",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",


### PR DESCRIPTION
This PR was opened by the [Changesets](https://github.com/gnosis/changesets-action-github-releases) GitHub action. When you\'re ready to do a release, you can merge this and publish to npm yourself. If you\'re not ready to do a release yet, that\'s fine, whenever you add more changesets to main, this PR will be updated.

# Releases

## @safe-global/safe-apps-provider@0.18.1

### Patch Changes

-   d6baa64: fallback `value` and `data` were overwritten with `undefined`
