### PR TITLE
Fix: export RPC_CALLS from index

### DIFF
--- a/.changeset/dry-parents-learn.md
+++ b/.changeset/dry-parents-learn.md
@@ -1,0 +1,5 @@
+---
+'@safe-global/safe-apps-sdk': patch
+---
+
+Export RPC_CALLS as an object

--- a/packages/safe-apps-sdk/src/index.ts
+++ b/packages/safe-apps-sdk/src/index.ts
@@ -6,3 +6,4 @@ export * from './types/index.js';
 export * from './communication/methods.js';
 export * from './communication/messageFormatter.js';
 export { getSDKVersion } from './version.js';
+export * from './eth/constants.js';


### PR DESCRIPTION
Resolves #539.

Re-exports RPC_CALLS from the index file.