### PR TITLE
Docs: fix regex syntax in SDK examples

### DIFF
--- a/packages/safe-apps-sdk/README.md
+++ b/packages/safe-apps-sdk/README.md
@@ -54,7 +54,7 @@ type Opts = {
 };
 
 const opts: Opts = {
-  allowedDomains: [/app.safe.global$/],
+  allowedDomains: [/^app\.safe\.global$/],
   debug: false,
 };
 


### PR DESCRIPTION
Fix a misleading regex example as pointed out by an external contributor.