### PR TITLE
docs: fix regex syntax in SDK exapmples

### DIFF
--- a/packages/safe-apps-sdk/README.md
+++ b/packages/safe-apps-sdk/README.md
@@ -54,7 +54,7 @@ type Opts = {
 };
 
 const opts: Opts = {
-  allowedDomains: [/app.safe.global$/],
+  allowedDomains: [/^app\.safe\.global$/],
   debug: false,
 };
 

--- a/packages/safe-apps-wagmi/README.md
+++ b/packages/safe-apps-wagmi/README.md
@@ -24,7 +24,7 @@ const config = createConfig({
     new SafeConnector({
       chains,
       options: {
-        allowedDomains: [/app.safe.global$/],
+        allowedDomains: [/^app\.safe\.global$/],
         debug: false,
       },
     }),


### PR DESCRIPTION
Fix a misleading regex example as pointed out by an external contributor.