### PR TITLE
Update EIP-5792 support, fixing pending status

### DIFF
--- a/.changeset/great-mails-warn.md
+++ b/.changeset/great-mails-warn.md
@@ -1,0 +1,5 @@
+---
+'@safe-global/safe-apps-provider': patch
+---
+
+Update EIP-5792 implementation according to spec. and fix pending status

--- a/packages/safe-apps-provider/src/provider.ts
+++ b/packages/safe-apps-provider/src/provider.ts
@@ -234,15 +234,18 @@ export class SafeAppProvider extends EventEmitter implements EIP1193Provider {
           [TransactionStatus.SUCCESS]: 'CONFIRMED',
         };
 
-        const tx = await this.sdk.txs.getBySafeTxHash(params[0]).catch(() => null);
-        if (!tx?.txHash) {
-          throw new Error('Transaction not found');
+        const tx = await this.sdk.txs.getBySafeTxHash(params[0]);
+
+        const status = CallStatus[tx.txStatus];
+
+        // Transaction is queued
+        if (!tx.txHash) {
+          return {
+            status,
+          };
         }
 
-        const receipt = await this.sdk.eth.getTransactionReceipt([tx.txHash]).catch(() => null);
-        if (!receipt) {
-          throw new Error('Transaction receipt not found');
-        }
+        const receipt = await this.sdk.eth.getTransactionReceipt([tx.txHash]);
 
         const calls =
           tx.txData?.dataDecoded?.method !== 'multiSend'
@@ -255,17 +258,17 @@ export class SafeAppProvider extends EventEmitter implements EIP1193Provider {
         const gasUsed = Number(receipt.gasUsed);
 
         const receipts = Array(calls).fill({
-          success: numberToHex(tx.txStatus === TransactionStatus.SUCCESS ? 1 : 0),
+          logs: receipt.logs,
+          status: numberToHex(tx.txStatus === TransactionStatus.SUCCESS ? 1 : 0),
+          chainId: numberToHex(this.chainId),
           blockHash: receipt.blockHash,
           blockNumber: numberToHex(blockNumber),
-          blockTimestamp: numberToHex(tx.executedAt ?? 0),
           gasUsed: numberToHex(gasUsed),
           transactionHash: tx.txHash,
-          logs: receipt.logs,
         });
 
         return {
-          status: CallStatus[tx.txStatus],
+          status,
           receipts,
         };
       }


### PR DESCRIPTION
## Summary

The EIP-5792 spec. has been adjusted, and it is not possible to get the `PENDING` status for a transaction that is queued off-chain.

This updates the implementation according to the current spec.:

- Changing `success` to `status`
- Adds `chainId`
- Removes `blockTimestamp`

Should a transaction not have a `txHash`, ergo being queued, it returns a `PENDING` status for it.

## Changes

- Change `success` to `status`
- Add `chainId`
- Remove `blockTimestamp`
- Return `PENDING` status for queued transactions