### PR TITLE
Fix Typo in `safe.test.ts`

### DIFF
--- a/packages/safe-apps-sdk/src/safe/safe.test.ts
+++ b/packages/safe-apps-sdk/src/safe/safe.test.ts
@@ -144,7 +144,7 @@ describe('Safe Apps SDK safe methods', () => {
       expect(await sdkInstance.safe.check1271Signature(message)).toEqual(true);
     });
 
-    test('Should return false if the message isnt signed and underlying call reverts', async () => {
+    test('Should return false if the message isn't signed and underlying call reverts', async () => {
       const safeInfoSpy = jest.spyOn(sdkInstance.safe, 'getInfo');
       // @ts-expect-error method is private but we are testing it
       const rpcCallSpy = jest.spyOn(sdkInstance.safe.communicator, 'send');


### PR DESCRIPTION
# Pull Request: Fix Typo in `safe.test.ts`

## Description
This pull request corrects a typo in the `safe.test.ts` file. Specifically, the comment regarding the test case has been updated:

- **Before**: "Should return false if the message isnt signed and underlying call reverts"
- **After**: "Should return false if the message isn't signed and underlying call reverts"

## Changes
- Corrected the typo "isnt" to "isn't" in the test description.

## Related Issue
- N/A (If there’s an issue associated with this change, link it here)

## Checklist
- [x] Code follows the repository’s coding conventions
- [x] Changes are described in the PR
- [ ] Tests have been added/updated (if applicable)
- [ ] Documentation has been updated (if needed)
