### PR TITLE
Add OffChainSignature support to `eth_signTypedData_v4`

### DIFF
--- a/packages/safe-apps-provider/src/provider.ts
+++ b/packages/safe-apps-provider/src/provider.ts
@@ -77,6 +77,11 @@ export class SafeAppProvider extends EventEmitter implements EIP1193Provider {
 
         const response = await this.sdk.txs.signTypedMessage(parsedTypedData);
         const signature = 'signature' in response ? response.signature : undefined;
+        if (!signature && 'messageHash' in response) {
+          // The returned signature will either be an empty string or valid one once the required number of Safe owners
+          // have confirmed the message.
+          return this.sdk.safe.getOffChainSignature(response.messageHash);
+        }
         return signature || '0x';
       }
 


### PR DESCRIPTION
Add OffChainSignature support to `eth_signTypedData_v4`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds off-chain signature handling for typed data requests.
> 
> - In `provider.ts`, when `sdk.txs.signTypedMessage` returns no `signature` but includes `messageHash`, fetch and return `sdk.safe.getOffChainSignature(messageHash)` instead of `0x` for `eth_signTypedData`/`eth_signTypedData_v4`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cc09d1fe279c043499ee7619a95822915508ffcb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->