### PR TITLE
chore: pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -12,7 +12,7 @@ jobs:
       - name: 'CLA Assistant'
         if: (github.event.comment.body == 'recheckcla' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
         # Beta Release
-        uses: contributor-assistant/github-action@v2.2.0
+        uses: contributor-assistant/github-action@b2a7f9fb90217ea0b8a0c95c288221457be4a31f # v2.2.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # the below token should have repo scope and must be manually added by you in the repository's secret

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,10 +5,10 @@ jobs:
   eslint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
 
       - name: Use Node.js 18
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3.9.1
         with:
           node-version: 18
           cache: yarn

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,13 +13,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
         with:
           # This makes Actions fetch all Git history so that Changesets can generate changelogs with the correct commits
           fetch-depth: 0
 
       - name: Setup Node.js 18
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3.9.1
         with:
           node-version: 18
 
@@ -28,6 +28,6 @@ jobs:
 
       - name: Create Version/Changelogs Pull Request or Create Github Releases
         id: changesets
-        uses: gnosis/changesets-action-github-releases@v1.2.0
+        uses: gnosis/changesets-action-github-releases@0c10ec15081f104b1ce721beadafddb9d2880336 # v1.2.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,9 +9,9 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
       - name: Use Node.js 18
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3.9.1
         with:
           node-version: 18
       - run: yarn install --frozen-lockfile


### PR DESCRIPTION
## What it solves

GitHub Actions referenced by mutable tags (e.g. `@v3`) can be silently re-pointed by a tag move, which is a supply-chain risk. GitHub itself recommends pinning third-party (and first-party) actions to a full commit SHA.

## How this PR fixes it

Replaced every `uses: owner/action@vX` reference across all four workflow files with `uses: owner/action@<full-sha> # <exact-version>`. The trailing comment records the exact released tag the SHA corresponds to (e.g. `v3.6.0`, `v3.9.1`) rather than the floating major (`v3`), so future updates are explicit.

Actions pinned:
- `actions/checkout` → `f43a0e5ff2bd294095638e18286ca9a3d1956744` (v3.6.0)
- `actions/setup-node` → `3235b876344d2a9aa001b8d1453c930bba69e610` (v3.9.1)
- `contributor-assistant/github-action` → `b2a7f9fb90217ea0b8a0c95c288221457be4a31f` (v2.2.0)
- `gnosis/changesets-action-github-releases` → `0c10ec15081f104b1ce721beadafddb9d2880336` (v1.2.0)

No behavioral change — the SHAs resolve to the same versions previously in use.

## How to test it

1. Open the Actions tab on this PR and confirm the `Test` and `ESLint check` workflows run and pass.
2. Inspect the workflow run logs to confirm each action resolves to the pinned SHA (the version comment matches).
3. Verify the CLA workflow is triggered on this PR (it uses the pinned `contributor-assistant/github-action`).

## Screenshots

N/A - no UI changes

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).